### PR TITLE
Fix collection Id display

### DIFF
--- a/core/collection-loader.js
+++ b/core/collection-loader.js
@@ -253,7 +253,16 @@ function getCollectionDisplayName(collectionId, metadata) {
                 return `💬 Chat: ${character.name}`;
             }
 
-            // Fallback to ID
+              // Fallback: extract character name from rawId if it follows pattern: charName_uuid
+            // Format: assistant_503c1099-b769-41e7-8e15-0d652cd6d1b4
+            const underscoreIndex = chatId.lastIndexOf('_');
+            if (underscoreIndex > 0) {
+                // Extract everything before the last underscore (the character name)
+                const charName = chatId.substring(0, underscoreIndex);
+                return `💬 Chat: ${charName}`;
+            }
+
+            // Final fallback to just the ID
             return `💬 Chat #${chatId.substring(0, 8)}`;
         }
 


### PR DESCRIPTION
Right now the name of the character in chat collections' name is cropped up to 8 symbols. This patch solves that:

1. First tries to match the current chat
2. Then tries to find the character in the characters list
3. NEW: Extracts the character name from the rawId by taking everything before the last underscore (which separates the character name from the UUID)
4. Falls back to showing first 8 chars only if none of the above work
This should now show "💬 Chat: assistant" instead of ""💬 Chat: assistan" 